### PR TITLE
Removing "datetime" requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,5 +14,5 @@ setuptools.setup(
     url="https://github.com/RheingoldRiver/river_mwclient",
     packages=setuptools.find_packages(),
     python_requires='>=3.6',
-    install_requires=['mwclient', 'mwparserfromhell', 'datetime']
+    install_requires=['mwclient', 'mwparserfromhell']
 )


### PR DESCRIPTION
datetime is part of the standard python library and adding datetime to install_requires installed the following package that was unused:
https://pypi.org/project/DateTime/